### PR TITLE
Only require swiftOrderSubscriber if swift orders won't be ignored

### DIFF
--- a/ts/sdk/src/jitter/baseJitter.ts
+++ b/ts/sdk/src/jitter/baseJitter.ts
@@ -102,7 +102,7 @@ export abstract class BaseJitter {
 			);
 		}
 
-		if (!this.swiftOrderSubscriber.userAccountGetter) {
+		if (!this.auctionSubscriberIgnoresSwiftOrders && !this.swiftOrderSubscriber.userAccountGetter) {
 			throw new Error(
 				'User account getter is required in swift order subscriber for jit integration'
 			);


### PR DESCRIPTION
Checks in the `BaseJitter` constructor require `swiftOrderSubscriber` even if `auctionSubscriberIgnoresSwiftOrders` is set to true.

This causes issues when running keeper bots repo (https://github.com/drift-labs/keeper-bots-v2/blob/5f1f7b8df5bac7daea4b505e8a01802daaf7c2d6/src/index.ts#L630) on localnet, as it either requires unnecessarily receiving Swift orders from other networks (that won't be and can't be processed anyway) or causes runtime errors.