### PR TITLE
ci: pin GitHub Actions to commit SHAs (FE-4376)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Install Solana Verify
         run: |
@@ -34,7 +34,7 @@ jobs:
           solana-verify build --library-name jit_proxy --base-image ellipsislabs/solana:1.16.6
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build
           path: target/deploy/jit_proxy.so

--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubicloud
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '24.x.x'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubicloud
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.5.0
+      uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.0
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: '3.10.10'
 


### PR DESCRIPTION
## What

Pin all floating GitHub Actions refs in this repo to full commit SHAs (with `# version` comments), across workflow files and composite `action.yml` files. SHAs are the exact commits each tag/branch currently resolves to.

## Why

Part of the org-wide GitHub Actions hardening effort ([FE-4376](https://linear.app/driftprotocol/issue/FE-4376/improve-github-actions-security)). The `drift-labs` org now has `sha_pinning_required: true` and is moving off `Allow all actions` to a selected-actions allow-list. Floating refs (`@v1`, `@master`, …) must be pinned to full SHAs first so neither the pin-enforcement policy nor the allow-list flip breaks CI. Pinning to a SHA is the actual supply-chain defense (a mutable `@master`/tag can be moved by a compromised maintainer).

## Scope

Action ref pins only — no logic changes. Behavior preserved (e.g. `dtolnay/rust-toolchain@stable` pins to the stable-branch commit whose `action.yml` still defaults to the stable channel).