### PR TITLE
chore: rename drift-labs GitHub URLs to velocity-exchange

### DIFF
--- a/.github/workflows/on-sdk-update.yml
+++ b/.github/workflows/on-sdk-update.yml
@@ -70,7 +70,7 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.GH_PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/repos/drift-labs/keeper-bots-v2/dispatches" \
+          "https://api.github.com/repos/velocity-exchange/keeper-bots-v2/dispatches" \
           -d "{\"event_type\": \"jit-sdk-update\", \"client_payload\": {
             \"sdk-version\": \"$SDK_VERSION\",
             \"jit-version\": \"$JIT_VERSION\"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 [[package]]
 name = "drift"
 version = "2.140.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
 dependencies = [
  "ahash 0.8.6",
  "anchor-lang",
@@ -978,7 +978,7 @@ dependencies = [
 [[package]]
 name = "drift-macros"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
+source = "git+https://github.com/velocity-exchange/drift-macros.git?rev=c57d87#c57d87e073d13d43f4d1fb09fe6822915a4ccc11"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1656,7 +1656,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openbook-v2-light"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
 dependencies = [
  "anchor-lang",
  "borsh 0.10.3",
@@ -1719,7 +1719,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "phoenix-v1"
 version = "0.2.4"
-source = "git+https://github.com/drift-labs/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
+source = "git+https://github.com/velocity-exchange/phoenix-v1?rev=7703c5#7703c50cf92f2bb321dcd1e2824e1c041135ec5c"
 dependencies = [
  "borsh 0.10.3",
  "bytemuck",
@@ -1823,7 +1823,7 @@ checksum = "44de48029c54ec1ca570786b5baeb906b0fc2409c8e0145585e287ee7a526c72"
 [[package]]
 name = "pyth-lazer-protocol"
 version = "0.1.2"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1836,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "pyth-lazer-solana-contract"
 version = "0.2.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=d790d1cb4da873a949cf33ff70349b7614b232eb#d790d1cb4da873a949cf33ff70349b7614b232eb"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "pyth-solana-receiver-sdk"
 version = "0.3.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
 dependencies = [
  "anchor-lang",
  "hex",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "pythnet-sdk"
 version = "2.1.0"
-source = "git+https://github.com/drift-labs/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
+source = "git+https://github.com/velocity-exchange/pyth-crosschain?rev=3e8a24ecd0bcf22b787313e2020f4186bb22c729#3e8a24ecd0bcf22b787313e2020f4186bb22c729"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2806,7 +2806,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "switchboard"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
 dependencies = [
  "anchor-lang",
 ]
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "switchboard-on-demand"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
+source = "git+https://github.com/velocity-exchange/protocol-v2.git?tag=v2.140.0#d315d880dd85cc59f10e5f788c8c64d65d52cd76"
 dependencies = [
  "anchor-lang",
  "bytemuck",

--- a/programs/jit-proxy/Cargo.toml
+++ b/programs/jit-proxy/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 anchor-lang = "0.29.0"
 anchor-spl = "0.29.0"
 bytemuck = { version = "1.4.0" }
-drift = { git = "https://github.com/drift-labs/protocol-v2.git", tag = "v2.140.0", features = ["cpi", "mainnet-beta"]}
+drift = { git = "https://github.com/velocity-exchange/protocol-v2.git", tag = "v2.140.0", features = ["cpi", "mainnet-beta"]}
 static_assertions = "1.1.0"
 solana-program = "1.16"
 ahash = "=0.8.6"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 [[package]]
 name = "drift-idl-gen"
 version = "0.1.3"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1263,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "drift-pubsub-client"
 version = "0.1.0"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
 dependencies = [
  "futures-util",
  "gjson",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "drift-rs"
 version = "1.0.0-alpha.11"
-source = "git+https://github.com/drift-labs/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
+source = "git+https://github.com/velocity-exchange/drift-rs?rev=5e1b5f8b#5e1b5f8b51c2143594f332fa47c7923081e8bb39"
 dependencies = [
  "abi_stable",
  "ahash 0.8.11",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 async-trait = "0.1.86"
 dashmap = "6"
 dotenv = "0.15.0"
-drift-rs = { git = "https://github.com/drift-labs/drift-rs", rev = "5e1b5f8b" }
+drift-rs = { git = "https://github.com/velocity-exchange/drift-rs", rev = "5e1b5f8b" }
 env_logger = "0.11"
 futures = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
Part of renaming the GitHub org drift-labs -> velocity-exchange.

**DRAFT — do not merge until the velocity-exchange org (and, where applicable, the @velocity-exchange npm scope) exists; old URLs currently redirect.**

## URL forms changed

- `github.com/drift-labs/` -> `github.com/velocity-exchange/` (Cargo.toml git deps, Cargo.lock sources, CI workflow dispatch target, CHANGELOG PR links)
- `@drift-labs/` npm scope -> `@velocity-exchange/` (package.json dep names, TypeScript import statements, yarn.lock entries, eslint rule message, CI workflow yarn-add command)

**Total substitutions: 38 across 15 files.**

## Files changed

| File | What changed |
|------|-------------|
| `.eslintrc.js` | eslint rule message referencing `@velocity-exchange/sdk` |
| `.github/workflows/on-sdk-update.yml` | `@velocity-exchange/sdk` dep lookup, yarn add command, keeper-bots-v2 dispatch URL |
| `CHANGELOG.md` | This repo's own PR links (7 links) |
| `Cargo.lock` | 10 git source URLs for protocol-v2, drift-macros, phoenix-v1, pyth-crosschain |
| `package.json` | `@velocity-exchange/sdk` dev dependency |
| `programs/jit-proxy/Cargo.toml` | `drift` git dep URL |
| `rust/Cargo.lock` | 3 drift-rs source URLs |
| `rust/Cargo.toml` | `drift-rs` git dep URL |
| `ts/sdk/package.json` | Package name `@velocity-exchange/jit-proxy`, `@velocity-exchange/sdk` dep |
| `ts/sdk/src/jitProxyClient.ts` | 2 import statements |
| `ts/sdk/src/jitter/baseJitter.ts` | 1 import statement |
| `ts/sdk/src/jitter/jitterShotgun.ts` | 1 import statement |
| `ts/sdk/src/jitter/jitterSniper.ts` | 1 import statement |
| `ts/sdk/yarn.lock` | `@velocity-exchange/sdk` lock entry |
| `yarn.lock` | `@velocity-exchange/sdk` lock entry |

## Skipped (upstream-Drift historical refs)

None — no historical/upstream Drift attribution references were found in this repository.

## Warning: npm scope breakage

`@drift-labs/sdk` and `@drift-labs/jit-proxy` have been renamed to `@velocity-exchange/sdk` and `@velocity-exchange/jit-proxy` respectively. **Builds will break until these packages are republished under the `@velocity-exchange` npm scope.** The `@drift-labs/jit-proxy` package name in `ts/sdk/package.json` has also been updated — downstream consumers that depend on `@drift-labs/jit-proxy` by name will need to update their own deps once this is published.